### PR TITLE
Update sensor.py to support Bresser 7003800 Base Station

### DIFF
--- a/custom_components/personal_weather_station/sensor.py
+++ b/custom_components/personal_weather_station/sensor.py
@@ -1,4 +1,5 @@
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.util import slugify
 from .const import DOMAIN, SENSOR_LIST
 
 
@@ -87,6 +88,7 @@ class PwsSensor(SensorEntity):
         self._meta = SENSOR_LIST.get(
             key, {"name": key, "icon": "mdi:help"}
         )
+        self._attr_has_entity_name = True
 
     @property
     def name(self):
@@ -95,6 +97,13 @@ class PwsSensor(SensorEntity):
     @property
     def unique_id(self):
         return f"{DOMAIN}_{self.device.device_id}_{self._key}".lower()
+
+    @property
+    def suggested_object_id(self):
+        """Prefix entity IDs with station/device id for easier discovery."""
+        sensor_part = slugify(self._meta.get("name", self._key))
+        station_part = slugify(self.device.device_id)
+        return f"{station_part}_{sensor_part}"
 
     @property
     def native_value(self):


### PR DESCRIPTION
Updated `sensor.py` and related integration flow to support Bresser WSLink HTTP GET ingestion and improve multi-station entity handling in Home Assistant.

High-level changes:
- Added station-aware `suggested_object_id` generation in `PwsSensor` using `slugify`, so new entities are created with a station-prefixed pattern:
  - `<station_id>_<sensor_name>`
- Enabled `_attr_has_entity_name = True` for modern HA naming behavior.
- Kept `name` as the base sensor label to avoid duplicated station text in UI names.
- Preserved stable `unique_id` format including station/device identifier.

HTTP GET compatibility updates (integration behavior):
- Added support for both WSLink endpoint paths:
  - `/weatherstation/updateweatherstation.php`
  - `/data/upload.php`
- Expanded device identifier parsing to accept both:
  - `ID` (legacy/custom)
  - `wsid` (WSLink documented)
- Updated request parsing to ignore both identifier keys (`ID`, `wsid`) as non-sensor fields.
- Improved missing-identifier response messaging for clarity.

Objective note:
- These changes adapt the integration to support the **Bresser Base Station 7003800** WSLink upload flow in Home Assistant, with clearer per-station entity organization and robust HTTP GET compatibility.