### PR TITLE
Allow API to be password protected

### DIFF
--- a/custom_components/personal_weather_station/__init__.py
+++ b/custom_components/personal_weather_station/__init__.py
@@ -2,6 +2,7 @@ from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD
 
 from .const import DOMAIN, SENSOR_LIST
 from .sensor import PwsSensor, PwsDevice
@@ -25,6 +26,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     #  Reference to the function that adds entities
     hass.data.setdefault(DOMAIN + "_add_entities", None)
 
+    # Listen for options updates
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+
     async def handle_request(request):
         """
         Handle HTTP requests from the weather station.
@@ -38,6 +42,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         # Extract all query parameters from the URL
         params = request.rel_url.query
+
+        # Check for password
+        # Check options first, then data
+        password = entry.options.get(CONF_PASSWORD)
+        if password is None:
+            password = entry.data.get(CONF_PASSWORD)
+
+        if password:
+            request_password = params.get("PASSWORD")
+            if request_password != password:
+                return web.json_response({"status": "error", "detail": "Invalid password"}, status=401)
 
         # Get the devices dictionary from hass.data
         devices = hass.data[DOMAIN + "_devices"]
@@ -72,8 +87,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         # Loop through all query parameters
         for key, value in params.items():
 
-            # Skip the "ID" parameter as it is not a sensor
-            if key == "ID":
+            # Skip the "ID" and "PASSWORD" parameter as it is not a sensor
+            if key == "ID" or key == "PASSWORD":
                 continue
 
             # Skip any key that is not in the predefined SENSOR_LIST
@@ -159,6 +174,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.pop(DOMAIN + "_add_entities", None)
 
     return True
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
+    """
+    Handle options update.
+
+    Args:
+        hass: Home Assistant instance.
+        entry: Config entry object.
+    """
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 class PwsView(HomeAssistantView):

--- a/custom_components/personal_weather_station/config_flow.py
+++ b/custom_components/personal_weather_station/config_flow.py
@@ -1,10 +1,47 @@
+"""Config flow for Personal Weather Station integration."""
 from homeassistant import config_entries
+from homeassistant.core import callback
+import voluptuous as vol
+from homeassistant.const import CONF_PASSWORD
 from .const import DOMAIN
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return OptionsFlowHandler(config_entry)
+
     async def async_step_user(self, user_input=None):
         if user_input is None:
-            return self.async_show_form(step_id="user", data_schema=None)
+            data_schema = vol.Schema({
+                vol.Optional(CONF_PASSWORD): str,
+            })
+            return self.async_show_form(
+                step_id="user",
+                data_schema=data_schema
+            )
 
-        return self.async_create_entry(title="Personal Weather Station", data={})
+        return self.async_create_entry(title="Personal Weather Station", data=user_input)
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+
+    def __init__(self, config_entry):
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                vol.Optional(
+                    CONF_PASSWORD,
+                    default=self._config_entry.options.get(
+                        CONF_PASSWORD,
+                        self._config_entry.data.get(CONF_PASSWORD, "")
+                    )
+                ): str
+            })
+        )

--- a/custom_components/personal_weather_station/translations/en.json
+++ b/custom_components/personal_weather_station/translations/en.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Personal Weather Station",
+        "description": "Set a station key here that your weather stations must transmit so that their data is not rejected. If you leave the field blank, all requests will be accepted.",
+        "data": {
+          "password": "Station Key"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Set a station key here that your weather stations must transmit so that their data is not rejected. If you leave the field blank, all requests will be accepted.",
+        "data": {
+          "password": "Station Key"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Since the /weatherstation/updateweatherstation.php endpoint is publicly accessible, adding password protection is a sensible security improvement. This PR introduces an optional Station Key field in Home Assistant.

- If set: Only requests with a PASSWORD GET parameter matching the key will be accepted.
- If left empty: All requests remain allowed, maintaining the integration's current behavior.

This ensures backward compatibility while providing an extra layer of security for those who need it.

Note: This implementation follows the standard for Bresser weather stations, which use the PASSWORD field specifically to transmit the station key.
