### PR TITLE
fix: Error 500 when trying to update values

### DIFF
--- a/custom_components/personal_weather_station/__init__.py
+++ b/custom_components/personal_weather_station/__init__.py
@@ -54,15 +54,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             if request_password != password:
                 return web.json_response({"status": "error", "detail": "Invalid password"}, status=401)
 
-        # Get the devices dictionary from hass.data
-        devices = hass.data[DOMAIN + "_devices"]
+        # Get the devices dictionary from hass.data.
+        # During reload there is a brief window where unload removed the key.
+        devices = hass.data.setdefault(DOMAIN + "_devices", {})
 
         # Get the reference to the function that adds new entities
         add_entities = hass.data.get(DOMAIN + "_add_entities")
 
         # If the sensor platform is not ready, return an error JSON response
         if not add_entities:
-            return web.json_response({"status": "error", "detail": "Sensor platform not ready"})
+            return web.json_response(
+                {"status": "error", "detail": "Sensor platform not ready"},
+                status=503,
+            )
 
         # Get the device ID from the query parameters
         device_id = params.get("ID")


### PR DESCRIPTION
In handle_request() (line 58), hass.data[DOMAIN + "_devices"] uses a hard bracket lookup. When the integration is reloaded (e.g., after HA restart or reload_config_entry), async_unload_entry removes this key before async_setup_entry re-adds it. Succeeding requests then return error 500. Reload of the integration solves this issue as a workaround.

fixes #24 